### PR TITLE
Less intrusive volumecontrol suggestions

### DIFF
--- a/src/volumecontrol.py
+++ b/src/volumecontrol.py
@@ -14,12 +14,17 @@ class VolumeControl(kp.Plugin):
     # The itemcategory of the suggestions of this package
     VOLUME_SUGGESTION = kp.ItemCategory.USER_BASE + 1
 
+    # Regular expression pattern for setting volume percentage with 
+    # any non-empty prefix of "volume" followed by a number
+    SET_VOLUME_REGEX = r'(?i)^(v(o(l(u(me?)?)?)?)?)+?\s*?(\d+)'
+
     # Target used to set the volume
     TARGET_SETVOLUME = "volume:set"
 
     def __init__(self):
         super().__init__()
         self.volume_control = IAudioEndpointVolume.get_default()
+        self.re_set_volume  = re.compile(SET_VOLUME_REGEX)
 
     def on_catalog(self):
         self.merge_catalog([
@@ -97,9 +102,9 @@ class VolumeControl(kp.Plugin):
 
     # Search for a number in a string
     def search_volume_level(self, text):
-        number = re.search(r'\d+', text)
-        if number:
-            number = int(number.group())
+        match = re.search(self.re_set_volume.search, text)
+        if match:
+            number = int(match.groups()[-1])
             return min(number, 100)
 
         return False

--- a/src/volumecontrol.py
+++ b/src/volumecontrol.py
@@ -24,7 +24,7 @@ class VolumeControl(kp.Plugin):
     def __init__(self):
         super().__init__()
         self.volume_control = IAudioEndpointVolume.get_default()
-        self.re_set_volume  = re.compile(SET_VOLUME_REGEX)
+        self.re_set_volume  = re.compile(self.SET_VOLUME_REGEX)
 
     def on_catalog(self):
         self.merge_catalog([
@@ -102,7 +102,7 @@ class VolumeControl(kp.Plugin):
 
     # Search for a number in a string
     def search_volume_level(self, text):
-        match = re.search(self.re_set_volume.search, text)
+        match = re.search(self.re_set_volume, text)
         if match:
             number = int(match.groups()[-1])
             return min(number, 100)


### PR DESCRIPTION
VolumeControl is very useful but its capturing of any number I type in the launch box take over higher priority items (it offers volume set suggestion for any text that has numbers in it). I am proposing a change that will add set volume suggestion only if launch text starts with any non-empty prefix of "volume" followed by a number. From the user perspective, instead of typing ```30``` to set volume at 30%, they would need to type something like ```v30```. Typing ```vs17``` (for Visual Studio 2017) would no longer suggest setting volume to 17%...

Comments:
1. I moved the regex to be precompiled otherwise it gets re-compiled a lot.
2. There may be more elegant way to match "volume" prefixes but I did not find it.